### PR TITLE
Add authentication via API token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,9 @@ The end user can set login variables for specific module(s) as local variables. 
 <p>
 By default, the priority will be given to <b>Local Variables</b> than <b>Environment Variables.</b>
 </p>
+<p>
+If "API_TOKEN" is passed in the <code>user</code> variable the <code>password</code> variable will be interpreted as <a href=https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html>API Access Token</a> and OAuth 2.0 based authentication is used instead of user credentials. This is useful if an <a href=https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Service-Provider-Admin-Portal-Guide/GUID-3326986B-931C-4FDE-AF47-D5A863191072.html>external identity provider</a> is configured for the authentication with vCloud Director.
+</p>
 <li>
 <h3>Response</h3>
 <p>VCD Ansible Modules provide sort of a unanimous response across all operations. The response shall contain atleast following properties,</p>

--- a/module_utils/vcd.py
+++ b/module_utils/vcd.py
@@ -7,6 +7,7 @@ from pyvcloud.vcd.client import TaskStatus
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from pyvcloud.vcd.client import BasicLoginCredentials
 from requests.packages import urllib3
+from requests import post
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -43,7 +44,15 @@ class VcdAnsibleModule(AnsibleModule):
                                  api_version=api_version,
                                  verify_ssl_certs=verify_ssl_certs)
 
-            self.client.set_credentials(BasicLoginCredentials(user, org, password))
+            if user != 'API_TOKEN':
+                self.client.set_credentials(BasicLoginCredentials(user, org, password))
+            else:
+                oAuthResponse = post(
+                    'https://{}/oauth/tenant/{}/token'.format(host, org),
+                    data={'grant_type': 'refresh_token', 'refresh_token': password},
+                ).json()
+                access_token = oAuthResponse['access_token']
+                self.client.rehydrate_from_token(access_token, True)
 
         except Exception as error:
             self.fail_json(msg='Login failed for user {} to org {}'.format(user, org))


### PR DESCRIPTION
Add support for authentication with API tokens as described in [Generate
an API Access Token][1]. The authentication follows RFC6749 (OAuth 2.0).
If the user is set to 'API_TOKEN' the password is interpreted as token
string and instead of setting the login credentials of the pyvcloud
client, the client's rehydrate_from_token function is called with the
optional argument is_jwt_token=True.

[1]: https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html